### PR TITLE
fix: rename package to notoriosti-env-manager for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "env-manager"
+name = "notoriosti-env-manager"
 version = "0.2.1"
 description = "Environment-aware configuration loader with GCP Secret Manager support"
 authors = [{ name = "Bastian Ibañez", email = "bastian.miba@gmail.com" }]


### PR DESCRIPTION
## Summary

- Renames PyPI package from `env-manager` to `notoriosti-env-manager`

## Why

`env-manager` was rejected by PyPI as too similar to an existing package. `notoriosti-env-manager` is available and follows the org-scoped naming convention.

## Install

```bash
pip install notoriosti-env-manager
```

Live at: https://pypi.org/project/notoriosti-env-manager/