### PR TITLE
feat: add origin aliases for local and gcp (v0.2.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,25 @@ Each variable must have at least one of `source` or `default`.
 | 4 | Active environment's `origin` field |
 | 5 | Default: `"local"` |
 
+### Origin Aliases
+
+Both `origin` fields and the `SECRET_ORIGIN` environment variable accept canonical names or any of their aliases (case-insensitive):
+
+| Canonical | Accepted aliases |
+|---|---|
+| `local` | `dotenv`, `env-file`, `.env` |
+| `gcp` | `gcp-secretmanager`, `gcp-secret-manager`, `secretmanager` |
+
+```yaml
+# These are all equivalent
+environments:
+  dev:
+    origin: dotenv      # same as local
+  prod:
+    origin: gcp-secretmanager  # same as gcp
+    gcp_project_id: my-project
+```
+
 ## GCP Project ID Resolution
 
 | Priority | Source |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "env-manager"
-version = "0.2.1"
+version = "0.2.2"
 description = "Environment-aware configuration loader with GCP Secret Manager support"
 authors = [{ name = "Bastian Ibañez", email = "bastian.miba@gmail.com" }]
 readme = "README.md"

--- a/src/env_manager/environment.py
+++ b/src/env_manager/environment.py
@@ -5,7 +5,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Optional
 
-_VALID_ORIGINS = {"local", "gcp"}
+ORIGIN_ALIASES: dict[str, str] = {
+    "dotenv":              "local",
+    "env-file":            "local",
+    ".env":                "local",
+    "gcp-secretmanager":   "gcp",
+    "secretmanager":       "gcp",
+    "gcp-secret-manager":  "gcp",
+}
+
+CANONICAL_ORIGINS: frozenset[str] = frozenset({"local", "gcp"})
+_VALID_ORIGINS = CANONICAL_ORIGINS | frozenset(ORIGIN_ALIASES)
 
 
 @dataclass
@@ -95,6 +105,9 @@ def parse_environments(
                 f"Environment '{env_name}' has invalid origin '{origin}'; "
                 f"expected one of {sorted(_VALID_ORIGINS)}"
             )
+
+        # Normalize aliases to their canonical origin name
+        origin = ORIGIN_ALIASES.get(origin, origin)
 
         # -- origin-specific fields -------------------------------------------
         dotenv_path: Optional[str] = None

--- a/src/env_manager/factory.py
+++ b/src/env_manager/factory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Optional
 
 from env_manager.base import SecretLoader
+from env_manager.environment import ORIGIN_ALIASES
 from env_manager.loaders import DotEnvLoader, GCPSecretLoader
 
 from env_manager.utils import logger
@@ -22,6 +23,7 @@ def create_loader(
     """Instantiate the appropriate loader for ``secret_origin``."""
 
     origin = (secret_origin or "local").strip().lower()
+    origin = ORIGIN_ALIASES.get(origin, origin)
 
     if origin == "local":
         logger.info("Loading secrets from .env")
@@ -41,5 +43,7 @@ def create_loader(
         return GCPSecretLoader(project_id=gcp_project_id)
 
     raise ValueError(
-        f"Unsupported SECRET_ORIGIN '{secret_origin}'. Expected 'local' or 'gcp'."
+        f"Unsupported SECRET_ORIGIN '{secret_origin}'. "
+        "Expected 'local' (aliases: 'dotenv', 'env-file', '.env') "
+        "or 'gcp' (aliases: 'gcp-secretmanager', 'gcp-secret-manager', 'secretmanager')."
     )

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from env_manager.environment import EnvironmentConfig, parse_environments
+from env_manager.environment import CANONICAL_ORIGINS, ORIGIN_ALIASES, EnvironmentConfig, parse_environments
 
 
 def test_no_environments_key_returns_empty_dict():
@@ -222,3 +222,38 @@ def test_dataclass_fields():
     assert cfg.origin == "local"
     assert cfg.dotenv_path == ".env"
     assert cfg.gcp_project_id is None
+
+
+@pytest.mark.parametrize("alias", ["dotenv", "env-file", ".env"])
+def test_local_origin_aliases_normalize_to_local(alias):
+    raw_config = {
+        "environments": {
+            "dev": {
+                "origin": alias,
+            }
+        }
+    }
+    result = parse_environments(raw_config)
+    assert result["dev"].origin == "local"
+    assert result["dev"].dotenv_path == ".env"
+
+
+@pytest.mark.parametrize("alias", ["DOTENV", "ENV-FILE", ".ENV"])
+def test_local_origin_aliases_case_insensitive(alias):
+    raw_config = {
+        "environments": {
+            "dev": {
+                "origin": alias,
+            }
+        }
+    }
+    result = parse_environments(raw_config)
+    assert result["dev"].origin == "local"
+
+
+def test_all_alias_targets_are_canonical_origins():
+    """Every alias must resolve to a value in CANONICAL_ORIGINS."""
+    for alias, target in ORIGIN_ALIASES.items():
+        assert target in CANONICAL_ORIGINS, (
+            f"Alias '{alias}' maps to '{target}', which is not a canonical origin"
+        )


### PR DESCRIPTION
## Summary

- Introduces a general `ORIGIN_ALIASES` dict in `environment.py` as the single source of truth for all origin aliases
- `local` now accepts: `dotenv`, `env-file`, `.env`
- `gcp` now accepts: `gcp-secretmanager`, `gcp-secret-manager`, `secretmanager`
- Aliases are case-insensitive and normalized to canonical names before any validation or loader logic runs
- `factory.py` imports `ORIGIN_ALIASES` directly — no duplication
- Added a structural test that enforces all alias targets must be canonical origins
- Documented aliases in README under a new "Origin Aliases" section
- Bumps version to `0.2.2`

## Test plan

- [ ] `pytest tests/test_environment.py` — 27 tests pass including 7 new alias tests
- [ ] `pytest tests/` — 143 passed, 2 pre-existing failures (missing fixture, unrelated)
- [ ] Adding a new alias for any origin requires only one line in `ORIGIN_ALIASES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)